### PR TITLE
Windows Headers Not Included

### DIFF
--- a/xswi/XMLWriter.m
+++ b/xswi/XMLWriter.m
@@ -24,8 +24,10 @@
  * THE SOFTWARE.
  ****************************************************************************/
 
+#if (AMISHARE_USING_GCC || AMISHARE_USING_CLANG)
 /* Before including anything, set essential platform option compiler switches */
 #include "PLT/BoxPLTPlatformTarget.h"
+#endif /* (AMISHARE_USING_GCC || AMISHARE_USING_CLANG) */
 
 #import "XMLWriter.h"
 

--- a/xswi/XMLWriter.m
+++ b/xswi/XMLWriter.m
@@ -24,6 +24,9 @@
  * THE SOFTWARE.
  ****************************************************************************/
 
+/* Before including anything, set essential platform option compiler switches */
+#include "PLT/BoxPLTPlatformTarget.h"
+
 #import "XMLWriter.h"
 
 #import <CoreFoundation/CFString.h>


### PR DESCRIPTION
To successfully compile on Windows, XMLWriter.m was modified to include Windows platform headers by adding #include "PLT/BoxPLTPlatformTarget.h".